### PR TITLE
changed splitting to rsplit()

### DIFF
--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -149,7 +149,7 @@ class SomfyShutter:
         device.increase_rolling_code()
 
     def on_message(self, message):
-        prefix, devicetype, component, address, topic = message.topic.split("/", 4)
+        prefix, devicetype, component, address, topic = message.topic.rsplit("/", 4)
         command = message.payload.decode()
 
         if prefix != self.prefix:


### PR DESCRIPTION
rsplit() splits from the right so that we can use prefixes with "/" now