### PR TITLE
Added state and position update for Somfy shutters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-slim
 
-LABEL org.opencontainers.image.url="https://github.com/bbock/mqtt_cul_server"
-LABEL org.opencontainers.image.authors="Bernhard Bock <bernhard@bock.nu>"
+LABEL org.opencontainers.image.url="https://github.com/zapccu/mqtt_cul_server"
+LABEL org.opencontainers.image.authors="Bernhard Bock <bernhard@bock.nu>, Dirk Braner (zapccu) <d.braner@gmx.net>"
 LABEL org.opencontainers.image.licenses="GPL-3.0"
 LABEL org.opencontainers.image.title="MQTT CUL server"
 LABEL org.opencontainers.image.description="Bridge to connect a CUL wireless transceiver with an MQTT broker"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ The software supports both the 433 MHz and 868 MHz hardware.
 For the CUL, you just need to configure the serial device of the dongle in
 `mqtt_cul_server.ini`.
 
+The name of the configuration file can be changed by specifying command line
+option `--config Filename`.
+
 ### Intertechno
 
 For Intertechno-based switches, you need to configure the system ID,

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ ARMv7 processors (Raspberry Pi). An example `docker-compose.yml` is included.
 auto-discovery](https://www.home-assistant.io/docs/mqtt/discovery/), which is
 supported by this software.
 
+## Installation
+
+For installation description on a Debian / Raspbian system with a connected CUL see [installation.md](/doc/installation.md)
+
 ## Configuration
 
 ### CUL

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -41,7 +41,7 @@ cd /var/lib/mqtt_cul_server/state
 vi myshutter.json    # example
 ```
 
-For syntax of Somfy state file see [somfy.md](/doc/somfy)
+For syntax of Somfy state file see [somfy.md](/doc/somfy.md)
 
 ## Create user and set rights
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -18,7 +18,7 @@ mkdir -p /var/lib/mqtt_cul_server/state/somfy
 mkdir /var/log/mqtt_cul_server
 
 cd /opt
-git clone https://github.com/bbock/mqtt_cul_server
+git clone https://github.com/zapccu/mqtt_cul_server
 cp /opt/mqtt_cul_server/mqtt_cul_server.ini /etc/mqtt_cul_server/.
 ```
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -1,0 +1,81 @@
+
+# Installation on Debian / Raspbian
+## Prerequisits
+* MQTT broker is already setup and running anywhere in your network
+* Python is installed on the target system
+* You are connected as user root to the target system
+
+## Create directories and clone files from repository
+
+```
+# Binaries
+mkdir /opt/mqtt_cul_server
+# Configuration
+mkdir /etc/mqtt_cul_server
+# Device states
+mkdir -p /var/lib/mqtt_cul_server/state/somfy
+# Logfile
+mkdir /var/log/mqtt_cul_server
+
+cd /opt
+git clone https://github.com/bbock/mqtt_cul_server
+cp /opt/mqtt_cul_server/mqtt_cul_server.ini /etc/mqtt_cul_server/.
+```
+
+## Change settings in configuration file
+
+```
+vi /etc/mqtt_cul_server/mqtt_cul_server.ini
+```
+
+* Set `CUL` to the device file of your CUL device
+* Set `statedir` to `/var/lib/mqtt_cul_server/state`
+* Set `logfile` to `/var/log/mqtt_cul_server/mqtt_cul_server.log`
+* Configure MQTT broker parameters in section `mqtt`
+
+
+## Create state file(s) for your Somfy devices
+
+```
+cd /var/lib/mqtt_cul_server/state
+vi myshutter.json    # example
+```
+
+For syntax of Somfy state file see [somfy.md](/doc/somfy)
+
+## Create user and set rights
+
+```
+useradd -d /var/lib/mqtt_cul_server mqttcul
+chown -R mqttcul:mqttcul /opt/mqtt_cul_server
+chown -R mqttcul:mqttcul /etc/mqtt_cul_server
+chown -R mqttcul:mqttcul /var/lib/mqtt_cul_server
+chown mqttcul:mqttcul /var/log/mqtt_cul_server
+```
+
+## Add service to system daemon
+
+```
+cd /etc/systemd/system
+```
+Create a new file `mqtt-cul-server.service` with the following content:
+```
+[Unit]
+Description=MQTT CUL Gateway
+After=network.target
+
+[Service]
+Type=idle
+Restart=on-failure
+User=mqttcul
+ExecStart=/bin/bash -c 'cd /opt/mqtt_cul_server/ && python3 mqtt_cul_server.py --config /etc/mqtt_cul_server/mqtt_cul_server.ini'
+
+[Install]
+WantedBy=multi-user.target
+```
+Enable and start the new service:
+```
+systemctl daemon-reload
+systemctl start mqtt-cul-server
+systemctl enable mqtt-cul-server
+```

--- a/doc/somfy.md
+++ b/doc/somfy.md
@@ -38,7 +38,7 @@ Currently, supported device classes are `shutter` and `shade`.
 The `address` must be a 6 character long hexadecimal address. You can choose freely,
 your shutters will learn it during pairing.
 
-The encryption key (`enc_key`) and rolling_code are updated by the software each time
+The encryption key (`enc_key`) and `rolling_code` are updated by the software each time
 a command is sent. If it doesn't match the state in the shutters, they will not accept
 the command. This is the primary security function of Somfy. If you loose this key or
 only have an outdated one from a backup, you need to re-pair.
@@ -46,11 +46,13 @@ only have an outdated one from a backup, you need to re-pair.
 The `up_time` and `down_time` values are optional. These parameters specify the time needed
 for opening or closing the shutter. The values are used to calculate the current
 position if the shutter is stopped.
-One can either configure these values manually (stop the time by hand) or automatically
+
+One can either configure these values manually (stop and enter the time by hand) or automatically
 by sending a CALIBRATE command. After sending CALIBRATE the state of the device is
 changing to "calibrating" and the shutter is closing. As soon as the shutter is 
-closed, press STOP. Two seconds later the shutter will be opened. When it's open,
+closed, press STOP. Two seconds later the shutter will be opened again. When it's open,
 press STOP again.
+
 Calibration can be interrupted by sending the CALIBRATE command again.
 If up_time and down_time are not speicified, only states "open" and "closed" are reported.
 

--- a/doc/somfy.md
+++ b/doc/somfy.md
@@ -22,6 +22,8 @@ file is:
   "address": "B0C004",
   "enc_key": 1,
   "rolling_code": 4125,
+  "up_time": 12,
+  "down_time": 10
 }
 ```
 
@@ -39,6 +41,10 @@ The encryption key is updated by the software each time a command is sent. If it
 doesn't match the state in the shutters, they will not accept the command. This
 is the primary security function of Somfy. If you loose this key or only have an
 outdated one from a backup, you need to re-pair.
+
+The up_time and down_time are optional. These parameters specify the time needed
+to switch between open and closed (0 and 100%) state. The values are used to
+calculate the current position if the shutter is stopped.
 
 The CUL is paired as a new, additional remote. You can continue using the existing
 remote in parallel.

--- a/doc/somfy.md
+++ b/doc/somfy.md
@@ -23,7 +23,8 @@ file is:
   "enc_key": 1,
   "rolling_code": 4125,
   "up_time": 12,
-  "down_time": 10
+  "down_time": 10,
+  "current_pos": 100
 }
 ```
 
@@ -43,11 +44,20 @@ is the primary security function of Somfy. If you loose this key or only have an
 outdated one from a backup, you need to re-pair.
 
 The up_time and down_time are optional. These parameters specify the time needed
-to switch between open and closed (0 and 100%) state. The values are used to
-calculate the current position if the shutter is stopped.
+for opening or closing the shutter. The values are used to calculate the current
+position if the shutter is stopped.
+One can either configure these values manually (stop the time by hand) or automatically
+by sending a CALIBRATE command. After sending CALIBRATE the state of the device is
+changing to "calibrating" and the shutter is closing. As soon as the shutter is 
+closed, press STOP. Two seconds later the shutter will be opened. When it's open,
+press STOP again.
+Calibration can be interrupted by sending the CALIBRATE command again.
+
+current_pos is the current position of a shutter. The default position is 100 (open).
 
 The CUL is paired as a new, additional remote. You can continue using the existing
 remote in parallel.
+
 
 ## Pairing
 

--- a/doc/somfy.md
+++ b/doc/somfy.md
@@ -30,20 +30,20 @@ file is:
 
 The filename doesn't matter as long as it ends with `.json`.
 
-The `name`attribute is just for reporting a user-friedly name on device discovery,
+The `name` attribute is just for reporting a user-friedly name on device discovery,
 it is not used for any other purpose.
 
 Currently, supported device classes are `shutter` and `shade`.
 
-The address must be a 6 character long hexadecimal address. You can choose freely,
+The `address` must be a 6 character long hexadecimal address. You can choose freely,
 your shutters will learn it during pairing.
 
-The encryption key is updated by the software each time a command is sent. If it
-doesn't match the state in the shutters, they will not accept the command. This
-is the primary security function of Somfy. If you loose this key or only have an
-outdated one from a backup, you need to re-pair.
+The encryption key (`enc_key`) and rolling_code are updated by the software each time
+a command is sent. If it doesn't match the state in the shutters, they will not accept
+the command. This is the primary security function of Somfy. If you loose this key or
+only have an outdated one from a backup, you need to re-pair.
 
-The up_time and down_time are optional. These parameters specify the time needed
+The `up_time` and `down_time` values are optional. These parameters specify the time needed
 for opening or closing the shutter. The values are used to calculate the current
 position if the shutter is stopped.
 One can either configure these values manually (stop the time by hand) or automatically
@@ -52,8 +52,9 @@ changing to "calibrating" and the shutter is closing. As soon as the shutter is
 closed, press STOP. Two seconds later the shutter will be opened. When it's open,
 press STOP again.
 Calibration can be interrupted by sending the CALIBRATE command again.
+If up_time and down_time are not speicified, only states "open" and "closed" are reported.
 
-current_pos is the current position of a shutter. The default position is 100 (open).
+`current_pos` is the current position of a shutter. The default position is 100 (open).
 
 The CUL is paired as a new, additional remote. You can continue using the existing
 remote in parallel.

--- a/doc/somfy.md
+++ b/doc/somfy.md
@@ -48,12 +48,8 @@ for opening or closing the shutter. The values are used to calculate the current
 position if the shutter is stopped.
 
 One can either configure these values manually (stop and enter the time by hand) or automatically
-by sending a CALIBRATE command. After sending CALIBRATE the state of the device is
-changing to "calibrating" and the shutter is closing. As soon as the shutter is 
-closed, press STOP. Two seconds later the shutter will be opened again. When it's open,
-press STOP again.
+by sending a CALIBRATE command. 
 
-Calibration can be interrupted by sending the CALIBRATE command again.
 If up_time and down_time are not speicified, only states "open" and "closed" are reported.
 
 `current_pos` is the current position of a shutter. The default position is 100 (open).
@@ -73,3 +69,13 @@ for that (on mine it's a pinhole button on the backside.)
 Then, send the string `PROG` to the MQTT `set` topic with the address you chose
 in the config file. The exact topic name can be found by listening to the 
 discovery messages, it is e.g. `homeassistant/cover/somfy/B0C102/set`
+
+## Calibrating
+
+After sending an MQTT set command with payload CALIBRATE the state of the device is
+changing to "calibrating" and the shutter is closing. As soon as the shutter is 
+closed, press STOP. Five seconds later the shutter will be opened again. When it's open,
+press STOP again. The measured values for up_time and down_time are written to the
+state file.
+
+Calibration can be interrupted by sending the CALIBRATE command again.

--- a/mqtt_cul_server.ini
+++ b/mqtt_cul_server.ini
@@ -2,7 +2,12 @@
 # serial device of CUL868 / CUL433
 CUL = /dev/ttyACM0
 baud_rate = 115200
-statedir = /state_dir
+
+# directory with device state files
+statedir = /var/lib/mqtt_cul_server/state
+
+# Logfile
+logfile = /var/log/mqtt_cul_server/error.log
 
 # prefix for MQTT topics. this default is compatible with Home Assistant
 prefix = homeassistant

--- a/mqtt_cul_server.ini
+++ b/mqtt_cul_server.ini
@@ -7,8 +7,11 @@ statedir = /state_dir
 # prefix for MQTT topics. this default is compatible with Home Assistant
 prefix = homeassistant
 
-# enable verbose logging
-verbose = false
+# enable verbose (info) logging
+verbose = true
+
+# enable debug logging, implicitly set verbose to true
+debug = true
 
 [mqtt]
 # connection parameters of MQTT broker

--- a/mqtt_cul_server.py
+++ b/mqtt_cul_server.py
@@ -17,8 +17,11 @@ if __name__ == "__main__":
     args = parser.parse_args()
     
     config = configparser.ConfigParser()
-    config.read(args.config)
-
+    try:
+        config.read(args.config)
+    except:
+        print(f"ERROR: Cannot read config file {args.config}")
+        
     level = logging.ERROR
     logger = logging.getLogger()
     if config["DEFAULT"].getboolean("verbose"):

--- a/mqtt_cul_server.py
+++ b/mqtt_cul_server.py
@@ -38,3 +38,5 @@ if __name__ == "__main__":
 
     mcs = MQTT_CUL_Server(config=config)
     mcs.start()
+    
+    sys.exit(0)

--- a/mqtt_cul_server.py
+++ b/mqtt_cul_server.py
@@ -16,7 +16,6 @@ if __name__ == "__main__":
     parser.add_argument('--config', default='mqtt_cul_server.ini')
     args = parser.parse_args()
     
-    print(f"reading config from {args.config}")
     config = configparser.ConfigParser()
     config.read(args.config)
 

--- a/mqtt_cul_server.py
+++ b/mqtt_cul_server.py
@@ -5,15 +5,12 @@ import argparse
 import configparser
 import logging
 import signal
-import time
 
 from mqtt_cul_server import MQTT_CUL_Server
 
 def signal_handler(sig, frame):
     """ called when SIGTERM received """
     logging.info("Received SIGTERM. Terminating")
-    mcs.stop()
-    time.sleep(1)
     sys.exit(0)
         
 if __name__ == "__main__":

--- a/mqtt_cul_server.py
+++ b/mqtt_cul_server.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import sys
 import argparse
 import configparser
 import logging
@@ -21,7 +22,8 @@ if __name__ == "__main__":
         config.read(args.config)
     except:
         print(f"ERROR: Cannot read config file {args.config}")
-        
+        sys.exit(1)
+
     level = logging.ERROR
     logger = logging.getLogger()
     if config["DEFAULT"].getboolean("verbose"):

--- a/mqtt_cul_server.py
+++ b/mqtt_cul_server.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import argparse
 import configparser
 import logging
 
@@ -7,8 +8,17 @@ from mqtt_cul_server import MQTT_CUL_Server
 
 if __name__ == "__main__":
     """Control devices via MQTT and CUL RF USB stick"""
+    
+    parser = argparse.ArgumentParser(
+        prog="mqtt_cul_server",
+        description="Bidrectional CUL2MQTT Gateway"
+    )
+    parser.add_argument('--config', default='mqtt_cul_server.ini')
+    args = parser.parse_args()
+    
+    print(f"reading config from {parser.config}")
     config = configparser.ConfigParser()
-    config.read("mqtt_cul_server.ini")
+    config.read(args.config)
 
     if config["DEFAULT"].getboolean("verbose"):
         logger = logging.getLogger()

--- a/mqtt_cul_server.py
+++ b/mqtt_cul_server.py
@@ -23,6 +23,8 @@ if __name__ == "__main__":
     logger = logging.getLogger()
     if config["DEFAULT"].getboolean("verbose"):
         level = logging.INFO
+    if config["DEFAULT"].getboolean("debug"):
+        level = logging.DEBUG
         
     logfile = config["DEFAULT"].get("logfile", '')
     if logfile != '':

--- a/mqtt_cul_server.py
+++ b/mqtt_cul_server.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
     else:
         logger.setLevel(level)
     
-	# Signal handler
+    # Signal handler
     signal.signal(signal.SIGTERM, signal_handler)
 
     mcs = MQTT_CUL_Server(config=config)

--- a/mqtt_cul_server.py
+++ b/mqtt_cul_server.py
@@ -25,12 +25,12 @@ if __name__ == "__main__":
 
     level = logging.ERROR
     logger = logging.getLogger()
-    if config["DEFAULT"].getboolean("verbose"):
+    if config.getboolean("DEFAULT", "verbose", fallback=False):
         level = logging.INFO
-    if config["DEFAULT"].getboolean("debug"):
+    if config.getboolean("DEFAULT", "debug", fallback=False):
         level = logging.DEBUG
         
-    logfile = config["DEFAULT"].get("logfile", '')
+    logfile = config.get("DEFAULT", "logfile", fallback='')
     if logfile != '':
         logging.basicConfig(filename=logfile, encoding='utf-8', level=level)
     else:

--- a/mqtt_cul_server.py
+++ b/mqtt_cul_server.py
@@ -11,7 +11,7 @@ from mqtt_cul_server import MQTT_CUL_Server
 def signal_handler(sig, frame):
     """ called when SIGTERM received """
     logging.info("Received SIGTERM. Terminating")
-    sys.exit(0)
+    mcs.stop()
         
 if __name__ == "__main__":
     """Control devices via MQTT and CUL RF USB stick"""

--- a/mqtt_cul_server.py
+++ b/mqtt_cul_server.py
@@ -5,6 +5,7 @@ import argparse
 import configparser
 import logging
 import signal
+import time
 
 from mqtt_cul_server import MQTT_CUL_Server
 
@@ -12,6 +13,8 @@ def signal_handler(sig, frame):
     """ called when SIGTERM received """
     logging.info("Received SIGTERM. Terminating")
     mcs.stop()
+    time.sleep(1)
+    sys.exit(0)
         
 if __name__ == "__main__":
     """Control devices via MQTT and CUL RF USB stick"""
@@ -41,7 +44,8 @@ if __name__ == "__main__":
         logging.basicConfig(filename=logfile, encoding='utf-8', level=level)
     else:
         logger.setLevel(level)
-        
+    
+	# Signal handler
     signal.signal(signal.SIGTERM, signal_handler)
 
     mcs = MQTT_CUL_Server(config=config)

--- a/mqtt_cul_server.py
+++ b/mqtt_cul_server.py
@@ -18,9 +18,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
     
     config = configparser.ConfigParser()
-    try:
-        config.read(args.config)
-    except:
+    fcount = config.read(args.config)
+    if len(fcount) == 0:
         print(f"ERROR: Cannot read config file {args.config}")
         sys.exit(1)
 

--- a/mqtt_cul_server.py
+++ b/mqtt_cul_server.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     parser.add_argument('--config', default='mqtt_cul_server.ini')
     args = parser.parse_args()
     
-    print(f"reading config from {parser.config}")
+    print(f"reading config from {args.config}")
     config = configparser.ConfigParser()
     config.read(args.config)
 

--- a/mqtt_cul_server.py
+++ b/mqtt_cul_server.py
@@ -20,9 +20,16 @@ if __name__ == "__main__":
     config = configparser.ConfigParser()
     config.read(args.config)
 
+    level = logging.ERROR
+    logger = logging.getLogger()
     if config["DEFAULT"].getboolean("verbose"):
-        logger = logging.getLogger()
-        logger.setLevel(logging.INFO)
+        level = logging.INFO
+        
+    logfile = config["DEFAULT"].get("logfile", '')
+    if logfile != '':
+        logging.basicConfig(filename=logfile, encoding='utf-8', level=level)
+    else:
+        logger.setLevel(level)
 
     mcs = MQTT_CUL_Server(config=config)
     mcs.start()

--- a/mqtt_cul_server.py
+++ b/mqtt_cul_server.py
@@ -4,9 +4,15 @@ import sys
 import argparse
 import configparser
 import logging
+import signal
 
 from mqtt_cul_server import MQTT_CUL_Server
 
+def signal_handler(sig, frame):
+    """ called when SIGTERM received """
+    logging.info("Received SIGTERM. Terminating")
+    sys.exit(0)
+        
 if __name__ == "__main__":
     """Control devices via MQTT and CUL RF USB stick"""
     
@@ -35,6 +41,8 @@ if __name__ == "__main__":
         logging.basicConfig(filename=logfile, encoding='utf-8', level=level)
     else:
         logger.setLevel(level)
+        
+    signal.signal(signal.SIGTERM, signal_handler)
 
     mcs = MQTT_CUL_Server(config=config)
     mcs.start()

--- a/mqtt_cul_server/__init__.py
+++ b/mqtt_cul_server/__init__.py
@@ -15,13 +15,12 @@ class MQTT_CUL_Server:
         self.mqtt_client = self.get_mqtt_client(config["mqtt"])
 
         # prefix for all MQTT topics
-        self.prefix = config["DEFAULT"]["prefix"]
-
-        statedir = config["DEFAULT"]["statedir"] or "state"
+        self.prefix = config.get("DEFAULT", "prefix", "homeassistant")
 
         if config["intertechno"].getboolean("enabled"):
             self.components["intertechno"] = intertechno.Intertechno(self.cul, self.mqtt_client, self.prefix, config["intertechno"])
         if config["somfy"].getboolean("enabled"):
+            statedir = config.get("DEFAULT", "statedir", "state")
             self.components["somfy"] = somfy_shutter.SomfyShutter(self.cul, self.mqtt_client, self.prefix, statedir)
         if config["lacrosse"].getboolean("enabled"):
             self.components["lacrosse"] = lacrosse.LaCrosse(self.cul, self.mqtt_client, self.prefix)

--- a/mqtt_cul_server/__init__.py
+++ b/mqtt_cul_server/__init__.py
@@ -34,6 +34,7 @@ class MQTT_CUL_Server:
         """ called when SIGTERM received """
         self.cul.exit_loop = True
         signal.pthread_kill(self.mqtt_listener.ident, signal.SIGKILL)
+        sys.exit(0)
 
     def get_mqtt_client(self, config):
         mqtt_client = mqtt.Client()

--- a/mqtt_cul_server/__init__.py
+++ b/mqtt_cul_server/__init__.py
@@ -32,8 +32,8 @@ class MQTT_CUL_Server:
     def signal_handler(self, sig, frame):
         """ called when SIGTERM received """
         self.cul.exit_loop = True
-        signal.pthread_kill(self.mqtt_listener.ident, signal.SIGINT)
-           
+        signal.pthread_kill(self.mqtt_listener.ident, signal.SIGKILL)
+
     def get_mqtt_client(self, mqtt_config):
         mqtt_client = mqtt.Client()
         mqtt_client.enable_logger()

--- a/mqtt_cul_server/__init__.py
+++ b/mqtt_cul_server/__init__.py
@@ -29,7 +29,7 @@ class MQTT_CUL_Server:
 		# Register signal handler
         signal.signal(signal.SIGTERM, self.signal_handler)
 
-    def signal_handler(self, signal, frame):
+    def signal_handler(self, sig, frame):
         """ called when SIGTERM received """
         self.cul.exit_loop = True
         signal.pthread_kill(self.mqtt_listener.ident, signal.SIGINT)

--- a/mqtt_cul_server/__init__.py
+++ b/mqtt_cul_server/__init__.py
@@ -25,12 +25,13 @@ class MQTT_CUL_Server:
             self.components["somfy"] = somfy_shutter.SomfyShutter(self.cul, self.mqtt_client, self.prefix, statedir)
         if config["lacrosse"].getboolean("enabled"):
             self.components["lacrosse"] = lacrosse.LaCrosse(self.cul, self.mqtt_client, self.prefix)
-            
+        
+		# Register signal handler
         signal.signal(signal.SIGTERM, self.signal_handler)
 
     def signal_handler(self, signal, frame):
-        if signal == signal.SIGTERM:
-            self.cul.exit_loop = True
+        """ called when SIGTERM received """
+        self.cul.exit_loop = True
             
     def get_mqtt_client(self, mqtt_config):
         mqtt_client = mqtt.Client()

--- a/mqtt_cul_server/__init__.py
+++ b/mqtt_cul_server/__init__.py
@@ -76,10 +76,17 @@ class MQTT_CUL_Server:
         """
 
     def on_rf_message(self, message):
-        """Handle message received via RF"""
+        """
+        Handle message received via RF
+        Hint: This function is also called when a command has been send to a device
+        => Added a dummy message handler for Somfy.
+        => Intertechno devices will still report an error.
+        """
         if not message: return
         if message[0:3] == "N01":
             self.components["lacrosse"].on_rf_message(message)
+        elif message[0:3] == "YsA":
+            self.components["somfy"].on_rf_message(message)
         else:
             logging.error("Can't handle RF message: %s", message)
 

--- a/mqtt_cul_server/__init__.py
+++ b/mqtt_cul_server/__init__.py
@@ -63,13 +63,13 @@ class MQTT_CUL_Server:
         try:
             _, _, component, _ = msg.topic.split("/", 3)
         except ValueError:
-            logging.debug("cannot parse topic: %s", msg.topic)
+            logging.error("cannot parse topic: %s", msg.topic)
             return
 
         if component in self.components:
             self.components[component].on_message(msg)
         else:
-            logging.debug("component %s unknown (topic %s)", component, msg.topic)
+            logging.warning("component %s unknown (topic %s)", component, msg.topic)
 
     def on_rf_message(self, message):
         """Handle message received via RF"""
@@ -77,7 +77,7 @@ class MQTT_CUL_Server:
         if message[0:3] == "N01":
             self.components["lacrosse"].on_rf_message(message)
         else:
-            logging.info("Can't handle RF message: %s", message)
+            logging.error("Can't handle RF message: %s", message)
 
     def start(self):
         """Start multiple threads to listen for MQTT and RF messages"""

--- a/mqtt_cul_server/__init__.py
+++ b/mqtt_cul_server/__init__.py
@@ -69,7 +69,7 @@ class MQTT_CUL_Server:
         if component in self.components:
             self.components[component].on_message(msg)
         """
-        The following log statement will generate warnings for each component under
+        The following log statement will generate warnings for each unknown component under
         "prefix". This makes no sense => commented it out
         else:
             logging.warning("component %s unknown (topic %s)", component, msg.topic)

--- a/mqtt_cul_server/__init__.py
+++ b/mqtt_cul_server/__init__.py
@@ -89,10 +89,11 @@ class MQTT_CUL_Server:
         self.mqtt_listener = threading.Thread(target=self.mqtt_client.loop_forever)
         self.mqtt_listener.start()
         # thread to listen for received RF messages
-        cul_listener = threading.Thread(target=self.cul.listen, args=[self.on_rf_message])
-        cul_listener.start()
+        self.cul_listener = threading.Thread(target=self.cul.listen, args=[self.on_rf_message])
+        self.cul_listener.start()
         
     def stop(self):
         """ stop threads """
         self.cul.exit_loop = True
+        signal.pthread_kill(self.cul_listener.ident, signal.SIGKILL)
         signal.pthread_kill(self.mqtt_listener.ident, signal.SIGKILL)       

--- a/mqtt_cul_server/__init__.py
+++ b/mqtt_cul_server/__init__.py
@@ -78,9 +78,9 @@ class MQTT_CUL_Server:
     def on_rf_message(self, message):
         """
         Handle message received via RF
-        Hint: This function is also called when a command has been send to a device
+        SOMFY: This function is also called when a command has been send to a device
+        with the acknowledge message (same enc_key and rolling code)
         => Added a dummy message handler for Somfy.
-        => Intertechno devices will still report an error.
         """
         if not message: return
         if message[0:3] == "N01":

--- a/mqtt_cul_server/__init__.py
+++ b/mqtt_cul_server/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import signal
 import threading
 import paho.mqtt.client as mqtt
 from . import cul
@@ -24,7 +25,13 @@ class MQTT_CUL_Server:
             self.components["somfy"] = somfy_shutter.SomfyShutter(self.cul, self.mqtt_client, self.prefix, statedir)
         if config["lacrosse"].getboolean("enabled"):
             self.components["lacrosse"] = lacrosse.LaCrosse(self.cul, self.mqtt_client, self.prefix)
+            
+        signal.signal(signal.SIGTERM, self.signal_handler)
 
+    def signal_handler(self, signal, frame):
+        if signal == signal.SIGTERM:
+            self.cul.exit_loop = True
+            
     def get_mqtt_client(self, mqtt_config):
         mqtt_client = mqtt.Client()
         mqtt_client.enable_logger()

--- a/mqtt_cul_server/__init__.py
+++ b/mqtt_cul_server/__init__.py
@@ -22,7 +22,7 @@ class MQTT_CUL_Server:
         if config["intertechno"].getboolean("enabled"):
             self.components["intertechno"] = intertechno.Intertechno(self.cul, self.mqtt_client, self.prefix, config["intertechno"])
         if config["somfy"].getboolean("enabled"):
-            statedir = config.get("DEFAULT", "statedir", "state")
+            statedir = config.get("DEFAULT", "statedir", fallback="state")
             self.components["somfy"] = somfy_shutter.SomfyShutter(self.cul, self.mqtt_client, self.prefix, statedir)
         if config["lacrosse"].getboolean("enabled"):
             self.components["lacrosse"] = lacrosse.LaCrosse(self.cul, self.mqtt_client, self.prefix)

--- a/mqtt_cul_server/__init__.py
+++ b/mqtt_cul_server/__init__.py
@@ -92,8 +92,3 @@ class MQTT_CUL_Server:
         self.cul_listener = threading.Thread(target=self.cul.listen, args=[self.on_rf_message])
         self.cul_listener.start()
         
-    def stop(self):
-        """ stop threads """
-        self.cul.exit_loop = True
-        signal.pthread_kill(self.cul_listener.ident, signal.SIGKILL)
-        signal.pthread_kill(self.mqtt_listener.ident, signal.SIGKILL)       

--- a/mqtt_cul_server/__init__.py
+++ b/mqtt_cul_server/__init__.py
@@ -28,10 +28,11 @@ class MQTT_CUL_Server:
             self.components["lacrosse"] = lacrosse.LaCrosse(self.cul, self.mqtt_client, self.prefix)
         
         # Register signal handler
-        signal.signal(signal.SIGTERM, self.signal_handler)
+        # signal.signal(signal.SIGTERM, self.signal_handler)
 
     def signal_handler(self, sig, frame):
         """ called when SIGTERM received """
+        logging.info("Received SIGTERM. Terminating")
         self.cul.exit_loop = True
         signal.pthread_kill(self.mqtt_listener.ident, signal.SIGKILL)
         sys.exit(0)

--- a/mqtt_cul_server/__init__.py
+++ b/mqtt_cul_server/__init__.py
@@ -32,7 +32,8 @@ class MQTT_CUL_Server:
     def signal_handler(self, signal, frame):
         """ called when SIGTERM received """
         self.cul.exit_loop = True
-            
+        signal.pthread_kill(self.mqtt_listener.ident, signal.SIGINT)
+           
     def get_mqtt_client(self, mqtt_config):
         mqtt_client = mqtt.Client()
         mqtt_client.enable_logger()
@@ -81,10 +82,8 @@ class MQTT_CUL_Server:
     def start(self):
         """Start multiple threads to listen for MQTT and RF messages"""
         # thread to listen for MQTT command messages
-        mqtt_listener = threading.Thread(target=self.mqtt_client.loop_forever)
-        mqtt_listener.start()
+        self.mqtt_listener = threading.Thread(target=self.mqtt_client.loop_forever)
+        self.mqtt_listener.start()
         # thread to listen for received RF messages
         cul_listener = threading.Thread(target=self.cul.listen, args=[self.on_rf_message])
         cul_listener.start()
-        print("CUL listener terminated. Sending stop to mqtt")
-        signal.pthread_kill(mqtt_listener.ident, signal.SIGTSTP)

--- a/mqtt_cul_server/__init__.py
+++ b/mqtt_cul_server/__init__.py
@@ -26,16 +26,6 @@ class MQTT_CUL_Server:
             self.components["somfy"] = somfy_shutter.SomfyShutter(self.cul, self.mqtt_client, self.prefix, statedir)
         if config["lacrosse"].getboolean("enabled"):
             self.components["lacrosse"] = lacrosse.LaCrosse(self.cul, self.mqtt_client, self.prefix)
-        
-        # Register signal handler
-        # signal.signal(signal.SIGTERM, self.signal_handler)
-
-    def signal_handler(self, sig, frame):
-        """ called when SIGTERM received """
-        logging.info("Received SIGTERM. Terminating")
-        self.cul.exit_loop = True
-        signal.pthread_kill(self.mqtt_listener.ident, signal.SIGKILL)
-        sys.exit(0)
 
     def get_mqtt_client(self, config):
         mqtt_client = mqtt.Client()
@@ -101,3 +91,8 @@ class MQTT_CUL_Server:
         # thread to listen for received RF messages
         cul_listener = threading.Thread(target=self.cul.listen, args=[self.on_rf_message])
         cul_listener.start()
+        
+    def stop(self):
+        """ stop threads """
+        self.cul.exit_loop = True
+        signal.pthread_kill(self.mqtt_listener.ident, signal.SIGKILL)       

--- a/mqtt_cul_server/__init__.py
+++ b/mqtt_cul_server/__init__.py
@@ -68,8 +68,12 @@ class MQTT_CUL_Server:
 
         if component in self.components:
             self.components[component].on_message(msg)
+        """
+        The following log statement will generate warnings for each component under
+        "prefix". This makes no sense => commented it out
         else:
             logging.warning("component %s unknown (topic %s)", component, msg.topic)
+        """
 
     def on_rf_message(self, message):
         """Handle message received via RF"""

--- a/mqtt_cul_server/__init__.py
+++ b/mqtt_cul_server/__init__.py
@@ -26,7 +26,7 @@ class MQTT_CUL_Server:
         if config["lacrosse"].getboolean("enabled"):
             self.components["lacrosse"] = lacrosse.LaCrosse(self.cul, self.mqtt_client, self.prefix)
         
-		# Register signal handler
+        # Register signal handler
         signal.signal(signal.SIGTERM, self.signal_handler)
 
     def signal_handler(self, sig, frame):

--- a/mqtt_cul_server/__init__.py
+++ b/mqtt_cul_server/__init__.py
@@ -86,3 +86,5 @@ class MQTT_CUL_Server:
         # thread to listen for received RF messages
         cul_listener = threading.Thread(target=self.cul.listen, args=[self.on_rf_message])
         cul_listener.start()
+        print("CUL listener terminated. Sending stop to mqtt")
+        signal.pthread_kill(mqtt_listener.ident, signal.SIGTSTP)

--- a/mqtt_cul_server/cul.py
+++ b/mqtt_cul_server/cul.py
@@ -42,13 +42,12 @@ class Cul(object):
                 self.serial.write(command_string)
 
                 # FIXME: this is lacrosse-specific and should not be in this class
-                self.serial.write(b"Nr1\n")
+                # self.serial.write(b"Nr1\n")
 
                 self.serial.flush()
             except serial.SerialException as e:
                 logging.error("Could not send command to CUL device %s", e)
                 sys.exit(1)
-
 
     def listen(self, callback):
         while not self.exit_loop:

--- a/mqtt_cul_server/cul.py
+++ b/mqtt_cul_server/cul.py
@@ -65,5 +65,5 @@ class Cul(object):
             except:
                 pass
             
-			# Wait 100ms before calling readline() again. Prevent high CPU load!
+            # Wait 100ms before calling readline() again. Prevent high CPU load!
             time.sleep(0.1)

--- a/mqtt_cul_server/cul.py
+++ b/mqtt_cul_server/cul.py
@@ -2,13 +2,15 @@ import sys
 import logging
 import os
 import serial
-
+import time
 
 class Cul(object):
     """Helper class to encapsulate serial communication with CUL device"""
 
     def __init__(self, serial_port, baud_rate=115200, test=False):
-        """Create instance with a given serial port"""
+        """
+        Create instance with a given serial port
+        """
         
         self.exit_loop = False
         
@@ -50,12 +52,18 @@ class Cul(object):
                 sys.exit(1)
 
     def listen(self, callback):
+        """
+        Listen for RF messages
+        """
         while not self.exit_loop:
-            # readline() blocks until message is available
             try:
+                # readline() blocks until message is available or timeout of 1s happens
                 message = self.serial.readline().decode("utf-8")
                 if message:
                     logging.debug("Received RF message: %s", message)
                 callback(message)
             except:
                 pass
+            
+			# Wait 100ms before calling readline() again. Prevent high CPU load!
+            time.sleep(0.1)

--- a/mqtt_cul_server/cul.py
+++ b/mqtt_cul_server/cul.py
@@ -60,3 +60,4 @@ class Cul(object):
                 callback(message)
             except:
                 pass
+        print("CUL listener stopped")

--- a/mqtt_cul_server/cul.py
+++ b/mqtt_cul_server/cul.py
@@ -9,6 +9,9 @@ class Cul(object):
 
     def __init__(self, serial_port, baud_rate=115200, test=False):
         """Create instance with a given serial port"""
+        
+        self.exit_loop = False
+        
         if test:
             self.serial = sys.stderr
             self.test = True
@@ -48,7 +51,7 @@ class Cul(object):
 
 
     def listen(self, callback):
-        while True:
+        while not self.exit_loop:
             # readline() blocks until message is available
             try:
                 message = self.serial.readline().decode("utf-8")

--- a/mqtt_cul_server/cul.py
+++ b/mqtt_cul_server/cul.py
@@ -60,4 +60,3 @@ class Cul(object):
                 callback(message)
             except:
                 pass
-        print("CUL listener stopped")

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -105,7 +105,7 @@ class SomfyShutter:
             """
             print(f"publishing devstate={devstate}, position={position}")
             self.mqtt_client.publish(self.base_path + "/state", payload=devstate, retain=True)
-            if position is not None and position != self.state["current_pos"]:
+            if position is not None and ("current_pos" not in self.state or position != self.state["current_pos"]):
                 self.state["current_pos"] = position
                 self.mqtt_client.publish(self.base_path + "/position", payload=position, retain=True)
                 self.save()

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -139,13 +139,13 @@ class SomfyShutter:
                 self.direction = 1
                 timeout = self.state["up_time"]
                 if "current_pos" in self.state:
-                    timeout *= (1 - self.state["current_pos"] / 100) + 1
+                    timeout = timeout * (1 - self.state["current_pos"] / 100) + 1
                 self.drv_timer = Timer(timeout, self.timer_open)
             else:
                 self.direction = -1
                 timeout = self.state["down_time"]
                 if "current_pos" in self.state:
-                    timeout *= self.state["current_pos"] / 100 + 1
+                    timeout = timeout * self.state["current_pos"] / 100 + 1
                 self.drv_timer = Timer(self.state["down_time"], self.timer_closed)
                 
             self.drv_timer.start()

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -256,7 +256,7 @@ class SomfyShutter:
 
     def log_message(self, message):
         """ log parts of a message """
-        if len(message) == 16:
+        if len(message) >= 16 and message[0:2] == "Ys":
             # Ignoring "Ys" at the beginning of the message
             enc_key = message[2:4]
             cmd = message[4:6]
@@ -336,16 +336,16 @@ class SomfyShutter:
                 time.sleep(5)
                 logging.info("Measuring up time for device %s. Press STOP when shutter is open and drive has stopped", address)
                 self.cal_start = time.time()
-                self.send_command("up", device)
+                self.send_command("up", device)    # Also save down time to state file
                 
             elif command == "STOP" and self.calibrate == 2:
                 """ measure up_time and stop calibration """
+                device.state["up_time"] = int(time.time() - self.cal_start)
+                device.save()
                 self.calibrate = 0
                 self.cal_start = 0
-                device.state["up_time"] = int(time.time() - self.cal_start)
                 logging.info("Measured up time of %d seconds for device %s", device.state["up_time"], address)
-                logging.ingo("Device %s calibrated", address)
-                self.send_command("my", device)    # also save state to file incl. up_time
+                logging.info("Device %s calibrated", address)
                 device.publish_devstate("open", 100)
                 
             elif command in cmd_lookup:

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -292,7 +292,8 @@ class SomfyShutter:
                     device.publish_devstate("stopped")
                 else:
                     """ start calibration, measure up and down time """
-                    logging.info("Calibration of device %s started", address)
+                    logging.info("Calibration of device %s started. Measuring down time. Press STOP when shutter is closed and drive has stopped",
+                                 address)
                     self.calibrate = 1
                     self.cal_start = time.time()
                     self.send_command("down", device)
@@ -302,9 +303,10 @@ class SomfyShutter:
                 """ measure down_time """
                 self.calibrate = 2
                 device.state["down_time"] = int(time.time() - self.cal_start)
-                logging.info("Measured down time of %d seconds for device %s", device.state["down_time"], address)
-                self.send_command("my", device)    # also save state to file incl. down_time
-                time.sleep(2)
+                logging.info("Measured down time of %d seconds for device %s. Waiting 5 seconds before measuring up time",
+                             device.state["down_time"], address)
+                time.sleep(5)
+                logging.info("Measuring up time for device %s. Press STOP when shutter is open and drive has stopped", address)
                 self.cal_start = time.time()
                 self.send_command("up", device)
                 

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -198,19 +198,20 @@ class SomfyShutter:
             SSSSSS - Address (= remote channel)
             """
             commands = {
-                "my": 1,
-                "up": 2,
-                "my-up": 3,
-                "down": 4,
-                "my-down": 5,
-                "up-down": 6,
-                "my-up-down": 7,
-                "prog": 8,
-                "enable-sun": 9,
-                "disable-sun": 10,
+                "my": "10",
+                "stop": "11",
+                "up": "20",
+                "my-up": "30",
+                "down": "40",
+                "my-down": "50",
+                "up-down": "60",
+                "my-up-down": "70",
+                "prog": "80",
+                "wind-sun": "90",
+                "wind-only": "A0"
             }
             if command in commands:
-                command_string = "A{:01X}{:01X}0{:04X}{}".format(
+                command_string = "A{:01X}{}{:04X}{}".format(
                     self.state["enc_key"],
                     commands[command],
                     self.state["rolling_code"],
@@ -254,6 +255,13 @@ class SomfyShutter:
     def on_rf_message(self, message):
         """ dummy RF message handler """
         logging.debug("received SOMFY message %s", message)
+        if len(message) == 16:
+            enc_key = message[2:4]
+            cmd = message[4:6]
+            rolling_code = message[6:10]
+            # Bytes 1 and 3 must be swapped
+            address = message[14:16] + message[12:14] + message[10:12]
+            logging.info("enc_key=%s, cmd=%s, rolling_code=%s, address=%s", enc_key, cmd, rolling_code, address)     
         
     def on_message(self, message):
         """ MQTT message handler """

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -38,7 +38,7 @@ class SomfyShutter:
             self.cmd_time = 0        # Timestamp of last open or close command. Used to calculate stop position
             self.direction = 0       # 1 = opening, -1 = closing, 0 = stopped
             
-            if len(self.state["address"] != 6):
+            if len(self.state["address"]) != 6:
                 raise ValueError(f"Address in {statefile} must be 3 bytes long")
         
             self.base_path = prefix + "/cover/somfy/" + self.state["address"]

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -62,7 +62,6 @@ class SomfyShutter:
                 "payload_stop": "STOP",
                 "position_topic": self.base_path + "/position",
                 "state_topic": self.base_path + "/state",
-                "optimistic": True,
                 "device_class": self.state["device_class"],
                 "name": self.state["name"],
                 "unique_id": "somfy_" + self.state["address"],

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -360,5 +360,5 @@ class SomfyShutter:
                 
             else:
                 logging.error("Command %s is not supported", command)
-        else:
+        elif topic not in ("config", "state", "position"):
             logging.warning("ignoring topic %s", topic)

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -34,8 +34,8 @@ class SomfyShutter:
             Add up_time and down_time entries to .json state file of your Somfy device to enable up/down timers
             """
             self.drv_timer = None    # Timer for opening / closing the shutter
-            self.cmd_time = 0     # Timestamp of last open or close command. Used to calculate stop position
-            self.direction = 0    # 1 = opening, -1 = closing, 0 = stopped
+            self.cmd_time = 0        # Timestamp of last open or close command. Used to calculate stop position
+            self.direction = 0       # 1 = opening, -1 = closing, 0 = stopped
             
             self.base_path = prefix + "/cover/somfy/" + self.state["address"]
 
@@ -65,7 +65,19 @@ class SomfyShutter:
                 "unique_id": "somfy_" + self.state["address"],
             }
 
+            # Publish configuration
             self.mqtt_client.publish(self.base_path + "/config", payload=json.dumps(configuration), retain=True)
+            
+			# Publish current state and position
+            if "current_pos" in self.state:
+                if self.state["current_pos"] == 100:
+                    self.publish_devstate("open", 100)
+                elif self.state["current_pos"] == 0:
+                    self.publish_devstate("closed", 0)
+                else:
+                    self.publish_devstate("stopped", self.state["current_pos"])
+            else:
+                self.publish_devstate("stopped", 50)    # Current position is unknown
                   
         def save(self):
             """Save state to JSON file"""

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -21,7 +21,7 @@ class SomfyShutter:
     """
 
     class SomfyShutterState:
-        def __init__(self, mqtt_client, prefix, statedir, statefile, debug):
+        def __init__(self, mqtt_client, prefix, statedir, statefile):
             self.mqtt_client = mqtt_client
             
             self.statefile = statedir + "/somfy/" + statefile

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -5,6 +5,7 @@ This module implements the serial protocol of culfw for the Somfy
 wireless communication protocol.
 """
 
+import sys
 import json
 import logging
 import os
@@ -253,6 +254,7 @@ class SomfyShutter:
                         logging.error("Error reading state file %s", statefile)
         except:
             logging.error("Error reading state files from directory %s", statedir + "/somfy")
+            sys.exit(1)
 
     @classmethod
     def get_component_name(cls):

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -25,6 +25,7 @@ class SomfyShutter:
             self.mqtt_client = mqtt_client
             
             self.statefile = statedir + "/somfy/" + statefile
+            logging.info("Reading device config from statefile %s", self.statefile)
             with open(self.statefile, "r", encoding='utf8') as file_handle:
                 self.state = json.loads(file_handle.read())
 

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -257,16 +257,16 @@ class SomfyShutter:
             prefix, devicetype, component, address, topic = message.topic.rsplit("/", 4)
             command = message.payload.decode()
         except ValueError:
-            logging.debug("cannot parse topic: %s", message.topic)
+            logging.error("cannot parse topic: %s", message.topic)
             return            
 
         if prefix != self.prefix:
-            logging.info("Ignoring message due to prefix")
+            logging.warning("Ignoring message due to prefix")
             return
         if devicetype != "cover":
-            raise ValueError("Somfy can only handle covers")
+            logging.error("Unsupported device type %s", devicetype)
         if component != "somfy":
-            raise ValueError("Received command for different component")
+            logging.error("Received command for different component %s", component)
 
         device = None
         for d in self.devices:
@@ -274,7 +274,7 @@ class SomfyShutter:
                 device = d
                 break
         if not device:
-            raise ValueError("Device not found: %s", address)
+            logging.error("Device not found: %s", address)
 
         if topic == "set":
             cmd_lookup = { "OPEN": "up", "CLOSE": "down", "STOP": "my", "PROG": "prog" }
@@ -314,6 +314,6 @@ class SomfyShutter:
                 device.update_state(command)
                 
             else:
-                raise ValueError("Command %s is not supported", command)
+                logging.error("Command %s is not supported", command)
         else:
-            logging.debug("ignoring topic %s", topic)
+            logging.warning("ignoring topic %s", topic)

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -295,7 +295,7 @@ class SomfyShutter:
                 
             elif command in cmd_lookup:
                 self.send_command(cmd_lookup[command], device)
-                device.update(command)
+                device.update_state(command)
                 
             else:
                 raise ValueError("Command %s is not supported", command)

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -132,10 +132,10 @@ class SomfyShutter:
             self.cmd_time = time.time()
             if devstate == "opening":
                 self.direction = 1
-                self.drvtimer = Timer(self.state["up_time"], self.timer_open)
+                self.drv_timer = Timer(self.state["up_time"], self.timer_open)
             else:
                 self.direction = -1
-                self.drvtimer = Timer(self.state["down_time"], self.timer_closed)
+                self.drv_timer = Timer(self.state["down_time"], self.timer_closed)
             self.drv_timer.start()
             
         def update_state(self, cmd):

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -114,7 +114,7 @@ class SomfyShutter:
             self.publish_devstate("closed", position=0)
 
         def update_state(self, cmd):
-            """ publish state and position """
+            """ calculate position, publish state and position """
             if cmd == "OPEN":
                 if "up_time" in self.state:
                     self.publish_devstate("opening")
@@ -278,7 +278,7 @@ class SomfyShutter:
                 """ measure down_time """
                 self.calibrate = 2
                 device.state["down_time"] = time.time() - self.cal_start
-                self.send_command("my", device)
+                self.send_command("my", device)    # also save state to file incl. down_time
                 time.sleep(2)
                 self.cal_start = time.time()
                 self.send_command("up", device)
@@ -287,9 +287,8 @@ class SomfyShutter:
                 self.calibrate = 0
                 self.cal_start = 0
                 device.state["up_time"] = time.time() - self.cal_start
-                self.send_command("my", device)
+                self.send_command("my", device)    # also save state to file incl. up_time
                 device.publish_devstate("open", 100)
-                device.save()
             elif command in cmd_lookup:
                 self.send_command(cmd_lookup[command], device)
                 device.update(command)

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -68,7 +68,7 @@ class SomfyShutter:
             # Publish configuration
             self.mqtt_client.publish(self.base_path + "/config", payload=json.dumps(configuration), retain=True)
             
-			# Publish current state and position
+            # Publish current state and position
             if "current_pos" in self.state:
                 if self.state["current_pos"] == 100:
                     self.publish_devstate("open", 100)
@@ -149,7 +149,7 @@ class SomfyShutter:
                     
             elif cmd == "CLOSE":
                 if "down_time" in self.state:
-                    print(f"opening. setting timer to {self.state['down_time']}")
+                    print(f"closing. setting timer to {self.state['down_time']}")
                     self.start_timer("closing")
                 else:
                     self.publish_devstate("closed", position=0)
@@ -253,8 +253,12 @@ class SomfyShutter:
         device.increase_rolling_code()
 
     def on_message(self, message):
-        prefix, devicetype, component, address, topic = message.topic.rsplit("/", 4)
-        command = message.payload.decode()
+        try:
+            prefix, devicetype, component, address, topic = message.topic.rsplit("/", 4)
+            command = message.payload.decode()
+        except ValueError:
+            logging.debug("cannot parse topic: %s", message.topic)
+            return            
 
         if prefix != self.prefix:
             logging.info("Ignoring message due to prefix")

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -262,6 +262,7 @@ class SomfyShutter:
 
         if topic == "set":
             cmd_lookup = { "OPEN": "up", "CLOSE": "down", "STOP": "my", "PROG": "prog" }
+            
             if command == "CALIBRATE":
                 if self.calibrate > 0:
                     """ interrupt calibration """
@@ -274,6 +275,7 @@ class SomfyShutter:
                     self.cal_start = time.time()
                     self.send_command("down", device)
                     device.publish_devstate("calibrating")
+                    
             elif command == "STOP" and self.calibrate == 1:
                 """ measure down_time """
                 self.calibrate = 2
@@ -282,6 +284,7 @@ class SomfyShutter:
                 time.sleep(2)
                 self.cal_start = time.time()
                 self.send_command("up", device)
+                
             elif command == "STOP" and self.calibrate == 2:
                 """ measure up_time and stop calibration """
                 self.calibrate = 0
@@ -289,9 +292,11 @@ class SomfyShutter:
                 device.state["up_time"] = time.time() - self.cal_start
                 self.send_command("my", device)    # also save state to file incl. up_time
                 device.publish_devstate("open", 100)
+                
             elif command in cmd_lookup:
                 self.send_command(cmd_lookup[command], device)
                 device.update(command)
+                
             else:
                 raise ValueError("Command %s is not supported", command)
         else:

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -253,7 +253,7 @@ class SomfyShutter:
 
     def on_rf_message(self, message):
         """ dummy RF message handler """
-        logging.debug("received message %s", message)
+        logging.debug("received SOMFY message %s", message)
         
     def on_message(self, message):
         """ MQTT message handler """

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -139,7 +139,7 @@ class SomfyShutter:
                     self.reset_timers()
                     self.cmd_time = time.time()
                     self.direction = -1
-                    self.ctimer = Timer(self.state["down_time"], self.timer_close)
+                    self.ctimer = Timer(self.state["down_time"], self.timer_closed)
                 else:
                     self.publish_devstate("closed", position=0)
                     

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -245,7 +245,10 @@ class SomfyShutter:
         self.devices = []
         for statefile in os.listdir(statedir + "/somfy/"):
             if ".json" in statefile:
-                self.devices.append(self.SomfyShutterState(mqtt_client, prefix, statedir, statefile))
+                try:
+                    self.devices.append(self.SomfyShutterState(mqtt_client, prefix, statedir, statefile))
+                except:
+                    logging.error("Error reading state file %s", statefile)
 
     @classmethod
     def get_component_name(cls):

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -273,7 +273,7 @@ class SomfyShutter:
                 device = d
                 break
         if not device:
-            logging.error("Device not found: %s", address)
+            logging.error("Device with address %s not found", address)
 
         if topic == "set":
             cmd_lookup = { "OPEN": "up", "CLOSE": "down", "STOP": "my", "PROG": "prog" }
@@ -281,11 +281,13 @@ class SomfyShutter:
             if command == "CALIBRATE":
                 if self.calibrate > 0:
                     """ interrupt calibration """
+                    logging.info("Calibration of device %s cancelled", address)
                     self.calibrate = 0
                     self.cal_start = 0
                     device.publish_devstate("stopped")
                 else:
                     """ start calibration, measure up and down time """
+                    logging.info("Calibration of device %s started", address)
                     self.calibrate = 1
                     self.cal_start = time.time()
                     self.send_command("down", device)
@@ -295,6 +297,7 @@ class SomfyShutter:
                 """ measure down_time """
                 self.calibrate = 2
                 device.state["down_time"] = int(time.time() - self.cal_start)
+                logging.info("Measured down time of %d seconds for device %s", device.state["down_time"], address)
                 self.send_command("my", device)    # also save state to file incl. down_time
                 time.sleep(2)
                 self.cal_start = time.time()
@@ -305,6 +308,8 @@ class SomfyShutter:
                 self.calibrate = 0
                 self.cal_start = 0
                 device.state["up_time"] = int(time.time() - self.cal_start)
+                logging.info("Measured up time of %d seconds for device %s", device.state["up_time"], address)
+                logging.ingo("Device %s calibrated", address)
                 self.send_command("my", device)    # also save state to file incl. up_time
                 device.publish_devstate("open", 100)
                 

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -204,8 +204,8 @@ class SomfyShutter:
             return command_string.encode()
 
     """
-	Implementation of class SomfyShutter
-	"""
+    Implementation of class SomfyShutter
+    """
     def __init__(self, cul, mqtt_client, prefix, statedir):
         self.cul = cul
         self.prefix = prefix

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -256,6 +256,7 @@ class SomfyShutter:
         logging.debug("received message %s", message)
         
     def on_message(self, message):
+        """ MQTT message handler """
         try:
             prefix, devicetype, component, address, topic = message.topic.rsplit("/", 4)
             command = message.payload.decode()

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -263,7 +263,7 @@ class SomfyShutter:
             rolling_code = message[6:10]
             # Address is stored in little endian format. Actually bytes 1 and 3 must be swapped
             # address = message[14:16] + message[12:14] + message[10:12]
-            address = message[10:]
+            address = message[10:16]
             
             logging.info("enc_key=%s, cmd=%s, rolling_code=%s, address=%s", enc_key, cmd, rolling_code, address)     
 

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -251,6 +251,10 @@ class SomfyShutter:
         self.cul.send_command(command_string)
         device.increase_rolling_code()
 
+    def on_rf_message(self, message):
+        """ dummy RF message handler """
+        logging.debug("received message %s", message)
+        
     def on_message(self, message):
         try:
             prefix, devicetype, component, address, topic = message.topic.rsplit("/", 4)

--- a/mqtt_cul_server/protocols/somfy_shutter.py
+++ b/mqtt_cul_server/protocols/somfy_shutter.py
@@ -243,12 +243,16 @@ class SomfyShutter:
         self.cal_start = 0
 
         self.devices = []
-        for statefile in os.listdir(statedir + "/somfy/"):
-            if ".json" in statefile:
-                try:
-                    self.devices.append(self.SomfyShutterState(mqtt_client, prefix, statedir, statefile))
-                except:
-                    logging.error("Error reading state file %s", statefile)
+
+        try:   
+            for statefile in os.listdir(statedir + "/somfy/"):
+                if ".json" in statefile:
+                    try:
+                        self.devices.append(self.SomfyShutterState(mqtt_client, prefix, statedir, statefile))
+                    except:
+                        logging.error("Error reading state file %s", statefile)
+        except:
+            logging.error("Error reading state files from directory %s", statedir + "/somfy")
 
     @classmethod
     def get_component_name(cls):

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 from setuptools import setup
 
 setup(name='mqtt_cul_server',
-      version='0.1',
+      version='0.3',
       description='A bridge to connect a CUL wireless tarnsceiver with an MQTT broker',
-      url='https://github.com/bbock/mqtt_cul_server',
-      author='Bernhard Bock',
-      author_email='bernhard@bock.nu',
+      url='https://github.com/zapccu/mqtt_cul_server',
+      author='Dirk Braner',
+      author_email='d.braner@gmx.net',
       license='GPL',
       packages=['mqtt_cul_server'],
       zip_safe=True)


### PR DESCRIPTION
Hi, 
this PR contains a lot of changes to your repo. I - more or less - rewrote somfy_shutter.py to support updates via mqtt for state and position of a shutter. The position is calculated by measuring the drive time (either manually or automatically).

To determine the up and down time of a shutter I introduced a new CALIBRATE command, which must be published in the payload of a mqtt set. I updated the doc in somfy.md accordingly. I also changed the config message sent to Homeassistant when the program is started (added state and position, removed optimistic).

I also made some minor changes to almost all other python files:

- Substituted some raise exception statements by logging statements to make the program more robust
- Added exception handlers for file I/O errors
- Handle signals to terminate the program gracefully when receiving a SIGTERM from systemd (prevent status "failed")
- Added a command line option for specifying an ini file
- Added a debug option to the ini file
- Added a logfile option to the ini file (all logging messages are written to this file)
- Fixed some bugs
- Added install.md with a description on how to install the program on a Debian or Raspbian system

Unfortunately there's still a bug in handling the Somfy device address. Actually the address must be stored in little endian format, currently it's in big endian format. So byte 1 and 3 should be swapped when composing the message. Changing this would break all existing device pairings. That's why I didn't change it.

Running the new version now for some days with 2 Somfy shutters and everything is working as expected.

BR